### PR TITLE
Prevent pip search for dependencies in other paths

### DIFF
--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -34,7 +34,7 @@ def ensure_pip(framework_path, version):
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    cmd = [python_path, "-m", "ensurepip"]
+    cmd = [python_path, "-s", "-m", "ensurepip"]
     print("Ensuring pip is installed...")
     subprocess.check_call(cmd)
 
@@ -47,7 +47,7 @@ def install(pkgname, framework_path, version):
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    cmd = [python_path, "-m", "pip", "install", pkgname]
+    cmd = [python_path, "-s", "-m", "pip", "install", pkgname]
     print("Installing %s..." % pkgname)
     subprocess.check_call(cmd)
 
@@ -60,7 +60,7 @@ def install_requirements(requirements_file, framework_path, version):
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    cmd = [python_path, "-m", "pip", "install", "-r", requirements_file]
+    cmd = [python_path, "-s", "-m", "pip", "install", "-r", requirements_file]
     print("Installing modules from %s..." % requirements_file)
     subprocess.check_call(cmd)
 


### PR DESCRIPTION
**Behavior:** Users having python3 from Brew could have used pip to install libraries in the '/Users/user/Library/Python/3.7/...'.  If you have previously installed a library in the mentioned folder the "new" pip will see that library as installed and it won't be available in your "relocated python". 

**How to reproduce it**: If you want to reproduce this behavior you should install python with brew (do it only for testing purpose...) and use pip3 to install 'xattr' then use relocatable-python and you won't get 'xattr' in your newly created framework.