### PR TITLE
Add --unsign / --no-unsign cmdline options to allow unsigning relocat…

### DIFF
--- a/locallibs/fix.py
+++ b/locallibs/fix.py
@@ -19,7 +19,12 @@ from __future__ import print_function
 
 import os
 import shutil
+import subprocess
 import sys
+
+
+UNSIGN_TOOL = "/usr/bin/codesign"
+
 
 def ensure_current_version_link(framework_path, short_version):
     '''Make sure the framework has Versions/Current'''
@@ -119,3 +124,17 @@ def fix_other_things(framework_path, short_version):
     future'''
     return (ensure_current_version_link(framework_path, short_version) and
             fix_script_shebangs(framework_path, short_version))
+
+
+def fix_broken_signatures(files_relocatablized):
+    """
+    Unsign the binaries and libraries that were relocatablized to avoid
+    them having corrupted signatures.
+    """
+    for file in files_relocatablized:
+        print("Unsigning %s to avoid broken signature." % file)
+        subprocess.check_call([
+            UNSIGN_TOOL,
+            "--remove-signature",
+            file,
+        ])

--- a/locallibs/relocatablizer.py
+++ b/locallibs/relocatablizer.py
@@ -247,9 +247,11 @@ def relocatablize(framework_path):
     )
     fix_modes(full_framework_path)
     framework_data = analyze(full_framework_path)
+    files_changed = set()
     for dylib in framework_data["dylibs"]:
         old_install_name = dylib["install_name"]
         new_install_name = relativize_install_name(dylib["path"])
+        files_changed.add(dylib["path"])
         # update other files with new install_name
         if old_install_name != new_install_name:
             files = (
@@ -260,7 +262,11 @@ def relocatablize(framework_path):
             for item in files:
                 if old_install_name in item["dependencies"]:
                     fix_dep(item["path"], old_install_name, new_install_name)
+                    files_changed.add(item["path"])
         print()
     # add rpaths to executables
     for item in framework_data["executables"]:
         add_rpath(item["path"])
+        files_changed.add(item["path"])
+
+    return files_changed

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -62,13 +62,6 @@ def main():
         "modules for macOS will be installed.",
     )
     parser.add_option(
-        "--unsign",
-        dest="unsign",
-        action="store_true",
-        help="Unsign binaries and libraries after they are relocatablized, "
-        "in order to avoid having invalid signatures.",
-    )
-    parser.add_option(
         "--no-unsign",
         dest="unsign",
         action="store_false",

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 import optparse
 
 from locallibs import get
-from locallibs.fix import fix_other_things
+from locallibs.fix import fix_broken_signatures, fix_other_things
 from locallibs.install import install_extras
 from locallibs.relocatablizer import relocatablize
 
@@ -61,6 +61,20 @@ def main():
         "Python modules to be installed. If not provided, certain useful "
         "modules for macOS will be installed.",
     )
+    parser.add_option(
+        "--unsign",
+        dest="unsign",
+        action="store_true",
+        help="Unsign binaries and libraries after they are relocatablized, "
+        "in order to avoid having invalid signatures.",
+    )
+    parser.add_option(
+        "--no-unsign",
+        dest="unsign",
+        action="store_false",
+        help="Do not unsign binaries and libraries after they are relocatablized."
+    )
+    parser.set_defaults(unsign=True)
     options, _arguments = parser.parse_args()
 
     framework_path = get.FrameworkGetter(
@@ -70,7 +84,9 @@ def main():
     ).download_and_extract(destination=options.destination)
 
     if framework_path:
-        relocatablize(framework_path)
+        files_relocatablized = relocatablize(framework_path)
+        if options.unsign:
+            fix_broken_signatures(files_relocatablized)
         short_version = ".".join(options.python_version.split(".")[0:2])
         install_extras(
             framework_path,


### PR DESCRIPTION
Add options to allow unsigning relocatablized Python binaries and libraries.

This PR uses Mac's default codesign binary with the --remove-signature flag to get rid of the corrupted
signature after relocatablizing.

Tests:

Original

% codesign --verify --verbose ./Python.framework/Versions/3.8/bin/python3.8
./Python.framework/Versions/3.8/bin/python3.8: invalid signature (code or signature have been modified)

After this change:
...
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libcrypto.1.1.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libncursesw.5.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libtk8.6.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libssl.1.1.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/Resources/Python.app/Contents/MacOS/Python to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/readline.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/Python to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libmenuw.5.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libtcl8.6.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/_curses_panel.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/_tkinter.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/_hashlib.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/_curses.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libpanelw.5.dylib to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/python3.8/lib-dynload/_ssl.cpython-38-darwin.so to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/bin/python3.8 to avoid broken signature.
Unsigning /Users/jjj/relocatable-python/Python.framework/Versions/3.8/lib/libformw.5.dylib to avoid broken signature.
...
% codesign --verify --verbose ./Python.framework/Versions/3.8/bin/python3.8
./Python.framework/Versions/3.8/bin/python3.8: code object is not signed at all
In architecture: x86_64