### PR TITLE
Add support to upgrade pip and install wheel prior to creating the bundle

### DIFF
--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -83,8 +83,8 @@ def install_requirements(requirements_file, framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_extras(framework_path, install_wheel, upgrade_pip, version="2.7",
-                   requirements_file=None):
+def install_extras(framework_path, version="2.7", requirements_file=None,
+                   install_wheel=False, upgrade_pip=False):
     """install all extra pkgs into Python framework path"""
     print()
     ensure_pip(framework_path, version)

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -83,8 +83,8 @@ def install_requirements(requirements_file, framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_extras(framework_path, version="2.7", requirements_file=None,
-                   install_wheel, upgrade_pip):
+def install_extras(framework_path, version="2.7", install_wheel, upgrade_pip,
+                   requirements_file=None):
     """install all extra pkgs into Python framework path"""
     print()
     ensure_pip(framework_path, version)

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -52,6 +52,19 @@ def install(pkgname, framework_path, version):
     subprocess.check_call(cmd)
 
 
+def upgrade_pip(framework_path, version):
+    """Use pip to upgrade pip"""
+    python_path = os.path.join(
+        framework_path, "Versions", version, "bin/python" + version
+    )
+    if not os.path.exists(python_path):
+        print("No python at %s" % python_path, file=sys.stderr)
+        return
+    cmd = [python_path, "-s", "-m", "pip", "install", "--upgrade", "pip"]
+    print("Upgrading pip installation...")
+    subprocess.check_call(cmd)
+
+
 def install_requirements(requirements_file, framework_path, version):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
@@ -70,10 +83,15 @@ def install_requirements(requirements_file, framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_extras(framework_path, version="2.7", requirements_file=None):
+def install_extras(framework_path, version="2.7", requirements_file=None,
+                   install_wheel, upgrade_pip):
     """install all extra pkgs into Python framework path"""
     print()
     ensure_pip(framework_path, version)
+    if upgrade_pip:
+        upgrade_pip(framework_path, version)
+    if install_wheel:
+        install("wheel", framework_path, version)
     if requirements_file:
         install_requirements(requirements_file, framework_path, version)
     elif version.startswith("2."):

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -26,7 +26,7 @@ PYTHON2_EXTRA_PKGS = ["xattr==0.6.4", "pyobjc"]
 PYTHON3_EXTRA_PKGS = ["cffi", "xattr", "pyobjc", "six"]
 
 
-def ensure_pip(framework_path, version):
+def ensure_pip(framework_path, upgrade_pip, version):
     """Ensure pip is installed in our Python framework"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -35,6 +35,8 @@ def ensure_pip(framework_path, version):
         print("No python at %s" % python_path, file=sys.stderr)
         return
     cmd = [python_path, "-s", "-m", "ensurepip"]
+    if upgrade_pip:
+        cmd.append("--upgrade")
     print("Ensuring pip is installed...")
     subprocess.check_call(cmd)
 
@@ -49,19 +51,6 @@ def install(pkgname, framework_path, version):
         return
     cmd = [python_path, "-s", "-m", "pip", "install", pkgname]
     print("Installing %s..." % pkgname)
-    subprocess.check_call(cmd)
-
-
-def upgrade_pip_install(framework_path, version):
-    """Use pip to upgrade pip"""
-    python_path = os.path.join(
-        framework_path, "Versions", version, "bin/python" + version
-    )
-    if not os.path.exists(python_path):
-        print("No python at %s" % python_path, file=sys.stderr)
-        return
-    cmd = [python_path, "-s", "-m", "pip", "install", "--upgrade", "pip"]
-    print("Upgrading pip installation...")
     subprocess.check_call(cmd)
 
 
@@ -87,9 +76,7 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
                    install_wheel=False, upgrade_pip=False):
     """install all extra pkgs into Python framework path"""
     print()
-    ensure_pip(framework_path, version)
-    if upgrade_pip:
-        upgrade_pip_install(framework_path, version)
+    ensure_pip(framework_path, upgrade_pip, version)
     if install_wheel:
         install("wheel", framework_path, version)
     if requirements_file:

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -52,7 +52,7 @@ def install(pkgname, framework_path, version):
     subprocess.check_call(cmd)
 
 
-def upgrade_pip(framework_path, version):
+def upgrade_pip_install(framework_path, version):
     """Use pip to upgrade pip"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -89,7 +89,7 @@ def install_extras(framework_path, install_wheel, upgrade_pip, version="2.7",
     print()
     ensure_pip(framework_path, version)
     if upgrade_pip:
-        upgrade_pip(framework_path, version)
+        upgrade_pip_install(framework_path, version)
     if install_wheel:
         install("wheel", framework_path, version)
     if requirements_file:

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -26,7 +26,7 @@ PYTHON2_EXTRA_PKGS = ["xattr==0.6.4", "pyobjc"]
 PYTHON3_EXTRA_PKGS = ["cffi", "xattr", "pyobjc", "six"]
 
 
-def ensure_pip(framework_path, upgrade_pip, version):
+def ensure_pip(framework_path, version):
     """Ensure pip is installed in our Python framework"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -35,8 +35,6 @@ def ensure_pip(framework_path, upgrade_pip, version):
         print("No python at %s" % python_path, file=sys.stderr)
         return
     cmd = [python_path, "-s", "-m", "ensurepip"]
-    if upgrade_pip:
-        cmd.append("--upgrade")
     print("Ensuring pip is installed...")
     subprocess.check_call(cmd)
 
@@ -51,6 +49,19 @@ def install(pkgname, framework_path, version):
         return
     cmd = [python_path, "-s", "-m", "pip", "install", pkgname]
     print("Installing %s..." % pkgname)
+    subprocess.check_call(cmd)
+
+
+def upgrade_pip_install(framework_path, version):
+    """Use pip to upgrade pip"""
+    python_path = os.path.join(
+        framework_path, "Versions", version, "bin/python" + version
+    )
+    if not os.path.exists(python_path):
+        print("No python at %s" % python_path, file=sys.stderr)
+        return
+    cmd = [python_path, "-s", "-m", "pip", "install", "--upgrade", "pip"]
+    print("Upgrading pip installation...")
     subprocess.check_call(cmd)
 
 
@@ -76,7 +87,9 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
                    install_wheel=False, upgrade_pip=False):
     """install all extra pkgs into Python framework path"""
     print()
-    ensure_pip(framework_path, upgrade_pip, version)
+    ensure_pip(framework_path, version)
+    if upgrade_pip:
+        upgrade_pip_install(framework_path, version)
     if install_wheel:
         install("wheel", framework_path, version)
     if requirements_file:

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -83,7 +83,7 @@ def install_requirements(requirements_file, framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_extras(framework_path, version="2.7", install_wheel, upgrade_pip,
+def install_extras(framework_path, install_wheel, upgrade_pip, version="2.7",
                    requirements_file=None):
     """install all extra pkgs into Python framework path"""
     print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -95,9 +95,9 @@ def main():
         short_version = ".".join(options.python_version.split(".")[0:2])
         install_extras(
             framework_path,
-            version=short_version,
             install_wheel=options.install_wheel,
             upgrade_pip=options.upgrade_pip,
+            version=short_version,
             requirements_file=options.pip_requirements,
         )
         if fix_other_things(framework_path, short_version):

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -96,9 +96,9 @@ def main():
         install_extras(
             framework_path,
             version=short_version,
-            requirements_file=options.pip_requirements,
             install_wheel=options.install_wheel,
             upgrade_pip=options.upgrade_pip,
+            requirements_file=options.pip_requirements,
         )
         if fix_other_things(framework_path, short_version):
             print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -41,6 +41,12 @@ def main():
         help="Override the base URL used to download the framework.",
     )
     parser.add_option(
+        "--install-wheel",
+        default=False,
+        action="store_true",
+        help="Install wheel prior to installing extra python modules."
+    )
+    parser.add_option(
         "--os-version",
         default=get.DEFAULT_OS_VERSION,
         help="Override the macOS version of the downloaded pkg. "
@@ -67,6 +73,12 @@ def main():
         action="store_false",
         help="Do not unsign binaries and libraries after they are relocatablized."
     )
+    parser.add_option(
+        "--upgrade-pip",
+        default=False,
+        action="store_true",
+        help="Upgrade pip prior to installing extra python modules."
+    )
     parser.set_defaults(unsign=True)
     options, _arguments = parser.parse_args()
 
@@ -85,6 +97,8 @@ def main():
             framework_path,
             version=short_version,
             requirements_file=options.pip_requirements,
+            install_wheel=options.install_wheel,
+            upgrade_pip=options.upgrade_pip,
         )
         if fix_other_things(framework_path, short_version):
             print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -95,10 +95,10 @@ def main():
         short_version = ".".join(options.python_version.split(".")[0:2])
         install_extras(
             framework_path,
-            install_wheel=options.install_wheel,
-            upgrade_pip=options.upgrade_pip,
             version=short_version,
             requirements_file=options.pip_requirements,
+            install_wheel=options.install_wheel,
+            upgrade_pip=options.upgrade_pip,
         )
         if fix_other_things(framework_path, short_version):
             print()


### PR DESCRIPTION
This adds support for the following:

1. Upgrade pip prior to using it (this could fix issues with bugs in installations, like pyobjc)
2. Installs `wheel` prior to installing the external modules/requirements file, so that we can speed up the process of making the relocatable python but also knowing that the developer of these modules has created the wheels themselves.