### PR TITLE
Universal2 build process fixes

### DIFF
--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -74,7 +74,7 @@ def install_requirements(requirements_file, install_wheel, framework_path,
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    if version.startswith("3.9") and not install_wheel:
+    if version.startswith("3.9"):
         # nasty hack to get xattr to install under 3.9.1rc1
         with open(requirements_file) as rfile:
             if "xattr" in rfile.read():

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -74,7 +74,7 @@ def install_requirements(requirements_file, install_wheel, framework_path,
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    if version.startswith("3.9") not install_wheel:
+    if version.startswith("3.9") and not install_wheel:
         # nasty hack to get xattr to install under 3.9.1rc1
         with open(requirements_file) as rfile:
             if "xattr" in rfile.read():

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -65,7 +65,8 @@ def upgrade_pip_install(framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_requirements(requirements_file, framework_path, version):
+def install_requirements(requirements_file, install_wheel, framework_path,
+                         version):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -73,7 +74,7 @@ def install_requirements(requirements_file, framework_path, version):
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    if version.startswith("3.9"):
+    if version.startswith("3.9") not install_wheel:
         # nasty hack to get xattr to install under 3.9.1rc1
         with open(requirements_file) as rfile:
             if "xattr" in rfile.read():
@@ -84,7 +85,7 @@ def install_requirements(requirements_file, framework_path, version):
 
 
 def install_extras(framework_path, version="2.7", requirements_file=None,
-                   install_wheel=False, upgrade_pip=False):
+                   install_wheel=True, upgrade_pip=True):
     """install all extra pkgs into Python framework path"""
     print()
     python_guard_path = os.path.expanduser(
@@ -107,7 +108,8 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
     if install_wheel:
         install("wheel", framework_path, version)
     if requirements_file:
-        install_requirements(requirements_file, framework_path, version)
+        install_requirements(requirements_file, install_wheel, framework_path,
+                             version)
     elif version.startswith("2."):
         for pkgname in PYTHON2_EXTRA_PKGS:
             print()

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -65,8 +65,8 @@ def upgrade_pip_install(framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_requirements(requirements_file, install_wheel, framework_path,
-                         version):
+def install_requirements(requirements_file, install_wheel, upgrade_pip,
+                         framework_path, version):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -79,6 +79,9 @@ def install_requirements(requirements_file, install_wheel, framework_path,
         with open(requirements_file) as rfile:
             if "xattr" in rfile.read():
                 install("cffi", framework_path, version)
+    # We can't upgrade pip until _after_ this hack for 3.9.1 RC1
+    if upgrade_pip:
+        upgrade_pip_install(framework_path, version)
     cmd = [python_path, "-s", "-m", "pip", "install", "-r", requirements_file]
     print("Installing modules from %s..." % requirements_file)
     subprocess.check_call(cmd)
@@ -103,13 +106,11 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
         print('*********************************************************')
         print()
     ensure_pip(framework_path, version)
-    if upgrade_pip:
-        upgrade_pip_install(framework_path, version)
     if install_wheel:
         install("wheel", framework_path, version)
     if requirements_file:
-        install_requirements(requirements_file, install_wheel, framework_path,
-                             version)
+        install_requirements(requirements_file, install_wheel, upgrade_pip,
+                             framework_path, version)
     elif version.startswith("2."):
         for pkgname in PYTHON2_EXTRA_PKGS:
             print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -41,10 +41,10 @@ def main():
         help="Override the base URL used to download the framework.",
     )
     parser.add_option(
-        "--install-wheel",
-        default=False,
-        action="store_true",
-        help="Install wheel prior to installing extra python modules."
+        "--no-wheel",
+        dest="install_wheel",
+        action="store_false",
+        help="Do not install wheel prior to installing extra python modules."
     )
     parser.add_option(
         "--os-version",
@@ -74,11 +74,13 @@ def main():
         help="Do not unsign binaries and libraries after they are relocatablized."
     )
     parser.add_option(
-        "--upgrade-pip",
-        default=False,
-        action="store_true",
-        help="Upgrade pip prior to installing extra python modules."
+        "--no-upgrade-pip",
+        dest="upgrade_pip",
+        action="store_false",
+        help="Do not upgrade pip prior to installing extra python modules."
     )
+    parser.set_defaults(install_wheel=True)
+    parser.set_defaults(upgrade_pip=True)
     parser.set_defaults(unsign=True)
     options, _arguments = parser.parse_args()
 


### PR DESCRIPTION
I've been working through numerous issues trying to get a complete universal2 build of python frameworks.

Some of the issues I've experienced (machine on Big Sur 11.0.1 on Intel mac)

1. Cannot properly build pyobjc 7.0.1 from source when using pip 20.2.3 (bundled in the 3.9.1 RC1 pkg)
2. Cannot properly get the cffi 1.14.4 wheel to contain universal mach-o binaries when using pip 20.3.0 and higher
3. Cannot get xattr to install from a `Requirements` file unless cffi is installed and compiled _prior_ to the pip install (the same issue worked around in the current main branch)

After trying several things, it looks like a very there is a very order of operations that it takes for me to get here.

1. Download 3.9.1 RC1
2. Install the `wheel` module
3. Using its pip (20.2.3) install `cffi` from the tarball and utilize it's `setup.py`. Since this version of pip does not know how to handle wheels for big sur, it will instead build from source
3. Immediately upgrade to pip 20.3.0 or 20.3.1
4. Start to install the `Requirements` file, which will now use a pip that handles Big Sur and grab the wheels.

This is the only way I have been able to create a fully universal python framework.

I worry that a future version of Python, say Python 3.9.1 RC2 will break all of this if they include pip 20.3 or higher.

I have posted on the cffi mailing list: https://groups.google.com/u/1/g/python-cffi/c/LtPdUxAT-M0 but I worry about long term support for https://github.com/macadmins/python and https://github.com/autopkg/autopkg that require significantly more python modules . Perhaps this is a short lived issue as developers get M1s in their hands and build the proper setup.py/wheels, but it certainly feels like this is going to be very painful, especially in the short term.

Pinging @nick.mcspadden for visibility