### PR TITLE
Remove hacks and use requirements.txt to solve the problem

### DIFF
--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -39,7 +39,7 @@ def ensure_pip(framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install(pkgname, framework_path, version):
+def install(pkgname, framework_path, version, compile=False):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -48,6 +48,9 @@ def install(pkgname, framework_path, version):
         print("No python at %s" % python_path, file=sys.stderr)
         return
     cmd = [python_path, "-s", "-m", "pip", "install", pkgname]
+    # If compile is set to true, pass --no-binary to force pip to compile source
+    if compile:
+        cmd += ["--no-binary", ":all:"]
     print("Installing %s..." % pkgname)
     subprocess.check_call(cmd)
 
@@ -77,7 +80,7 @@ def install_requirements(requirements_file, framework_path, version):
         # nasty hack to get xattr to install under 3.9.1rc1
         with open(requirements_file) as rfile:
             if "xattr" in rfile.read():
-                install("cffi", framework_path, version)
+                install("cffi", framework_path, version, compile=True)
     cmd = [python_path, "-s", "-m", "pip", "install", "-r", requirements_file]
     print("Installing modules from %s..." % requirements_file)
     subprocess.check_call(cmd)

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -39,7 +39,7 @@ def ensure_pip(framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install(pkgname, framework_path, version, compile=False):
+def install(pkgname, framework_path, version):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -48,9 +48,6 @@ def install(pkgname, framework_path, version, compile=False):
         print("No python at %s" % python_path, file=sys.stderr)
         return
     cmd = [python_path, "-s", "-m", "pip", "install", pkgname]
-    # If compile is set to true, pass --no-binary to force pip to compile source
-    if compile:
-        cmd += ["--no-binary", ":all:"]
     print("Installing %s..." % pkgname)
     subprocess.check_call(cmd)
 
@@ -76,18 +73,13 @@ def install_requirements(requirements_file, framework_path, version):
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
-    if version.startswith("3.9"):
-        # nasty hack to get xattr to install under 3.9.1rc1
-        with open(requirements_file) as rfile:
-            if "xattr" in rfile.read():
-                install("cffi", framework_path, version, compile=True)
     cmd = [python_path, "-s", "-m", "pip", "install", "-r", requirements_file]
     print("Installing modules from %s..." % requirements_file)
     subprocess.check_call(cmd)
 
 
 def install_extras(framework_path, version="2.7", requirements_file=None,
-                   install_wheel=False, upgrade_pip=False):
+                   upgrade_pip=False):
     """install all extra pkgs into Python framework path"""
     print()
     python_guard_path = os.path.expanduser(
@@ -107,8 +99,6 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
     ensure_pip(framework_path, version)
     if upgrade_pip:
         upgrade_pip_install(framework_path, version)
-    if install_wheel:
-        install("wheel", framework_path, version)
     if requirements_file:
         install_requirements(requirements_file, framework_path, version)
     elif version.startswith("2."):

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -41,12 +41,6 @@ def main():
         help="Override the base URL used to download the framework.",
     )
     parser.add_option(
-        "--install-wheel",
-        default=False,
-        action="store_true",
-        help="Install wheel prior to installing extra python modules."
-    )
-    parser.add_option(
         "--os-version",
         default=get.DEFAULT_OS_VERSION,
         help="Override the macOS version of the downloaded pkg. "
@@ -97,7 +91,6 @@ def main():
             framework_path,
             version=short_version,
             requirements_file=options.pip_requirements,
-            install_wheel=options.install_wheel,
             upgrade_pip=options.upgrade_pip,
         )
         if fix_other_things(framework_path, short_version):


### PR DESCRIPTION
This does two things:

1. Adds an option to force pip to compile at install time
2. Ensures that cffi has `compile=True` set when it is installed early in the run.

We could add an interface for this (like `--no-binary`) that forces everything to be compiled, but I think this is better done in the `py3_requirements.txt` file. The only reason I had to do it in line was because of the ordering issue with the build.