### PR TITLE
get: fix the template for macosx -> macos rename

### DIFF
--- a/locallibs/get.py
+++ b/locallibs/get.py
@@ -58,7 +58,12 @@ class FrameworkGetter(object):
     def download(self):
         """Downloads a macOS installer pkg from python.org.
            Returns path to the download."""
-        url = self.base_url % (
+        if self.base_url == DEFAULT_BASEURL and \
+           not self.os_version.startswith('10'):
+            base_url = self.base_url.replace('macosx', 'macos')
+        else:
+            base_url = self.base_url
+        url = base_url % (
             self.python_version,
             self.python_version,
             self.os_version,

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -44,7 +44,7 @@ def main():
         "--os-version",
         default=get.DEFAULT_OS_VERSION,
         help="Override the macOS version of the downloaded pkg. "
-        'Current supported versions are "10.6" and "10.9". '
+        'Current supported versions are "10.6", "10.9", and "11". '
         "Not all Python version and macOS version combinations are valid.",
     )
     parser.add_option(


### PR DESCRIPTION
The `x` stood for `10` which is no longer the case. As such, Python
releases no longer have it. To preserve compatibility with `%` format
specifiers in existing code, detect the default url template and make
the fix for versions not starting with `10` and remove the `x`.