### PR TITLE
Minor fixes for m1 building, and shebang fix for some modules

### DIFF
--- a/locallibs/fix.py
+++ b/locallibs/fix.py
@@ -65,9 +65,12 @@ def is_framework_shebang(framework_path, text):
     this_framework_shebang = (
         b"#!" + os.path.abspath(framework_path).encode("UTF-8"))
     default_framework_shebang = b"#!/Library/Frameworks/Python.framework"
+    xcode_shebang = b"#!/Library/Developer/CommandLineTools/usr/bin/python3"
     if text.startswith(this_framework_shebang):
         return True
     if text.startswith(default_framework_shebang):
+        return True
+    if text.startswith(xcode_shebang):
         return True
     return False
 
@@ -125,12 +128,12 @@ def fix_other_things(framework_path, short_version):
 
 def fix_broken_signatures(files_relocatablized):
     """
-    Re-sign the binaries and libraries that were relocatablized with ad-hoc 
+    Re-sign the binaries and libraries that were relocatablized with ad-hoc
     signatures to avoid them having invalid signatures and to allow them to
     run on Apple Silicon
     """
-    CODESIGN_CMD = ["/usr/bin/codesign", 
-                    "-s", "-", "--deep", "--force", 
+    CODESIGN_CMD = ["/usr/bin/codesign",
+                    "-s", "-", "--deep", "--force",
                     "--preserve-metadata=identifier,entitlements,flags,runtime"]
     for pathname in files_relocatablized:
         print("Re-signing %s with ad-hoc signature..."

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -23,7 +23,7 @@ import sys
 
 PYTHON2_EXTRA_PKGS = ["xattr==0.6.4", "pyobjc"]
 
-PYTHON3_EXTRA_PKGS = ["cffi", "xattr", "pyobjc", "six"]
+PYTHON3_EXTRA_PKGS = ["wheel", "cffi", "xattr", "pyobjc", "six"]
 
 
 def ensure_pip(framework_path, version):
@@ -97,11 +97,7 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
         print('*********************************************************')
         print()
     ensure_pip(framework_path, version)
-    if upgrade_pip:
-        upgrade_pip_install(framework_path, version)
-    if requirements_file:
-        install_requirements(requirements_file, framework_path, version)
-    elif version.startswith("2."):
+    if version.startswith("2."):
         for pkgname in PYTHON2_EXTRA_PKGS:
             print()
             install(pkgname, framework_path, version)
@@ -109,3 +105,7 @@ def install_extras(framework_path, version="2.7", requirements_file=None,
         for pkgname in PYTHON3_EXTRA_PKGS:
             print()
             install(pkgname, framework_path, version)
+    if upgrade_pip:
+        upgrade_pip_install(framework_path, version)
+    if requirements_file:
+        install_requirements(requirements_file, framework_path, version)


### PR DESCRIPTION
- Fix for things like pylint using CMDLineTools dir
- Minor fix for m1, wheel needs to be installed

Some modules (like pylint) were installing using `#!/Library/Developer/CommandLineTools/usr/bin/python3` and were skipped by the framework fix. This fixes that. Still not entirely sure why that was being picked on a clean system.

To build successfully on m1, wheel needed to be added for xattr (cffi specifically) to install. They also needed to be installed ahead of all other items that may depend on them in a requirements file. 

With these mods, I've been able to get our additional items needed with no problem on m1 or intel.