### PR TITLE
Additional fixes around error codes

### DIFF
--- a/locallibs/get.py
+++ b/locallibs/get.py
@@ -115,5 +115,4 @@ class FrameworkGetter(object):
             self.extract_framework()
             return destination
         except subprocess.CalledProcessError as err:
-            print("%s" % err, file=sys.stderr)
-            return None
+            sys.exit("%s" % err)

--- a/locallibs/get.py
+++ b/locallibs/get.py
@@ -70,7 +70,7 @@ class FrameworkGetter(object):
         )
         (file_handle, destination_path) = tempfile.mkstemp()
         os.close(file_handle)
-        cmd = [CURL, "-o", destination_path, url]
+        cmd = [CURL, "--fail", "-o", destination_path, url]
         print("Downloading %s..." % url)
         subprocess.check_call(cmd)
         self.downloaded_pkg_path = destination_path


### PR DESCRIPTION
- Add --fail to fail on bad url's (404)
- Changing to sys.exit to return proper error code

Previously, when used in any wrapper scripts, the relocatable framework process would exit with error code 0 on bad curl downloads (test with --version=4.0.0).
It would continue to download to an html file which then would continue to pkgutil and would fail. Now it exits on bad url return codes. 

Even then it would still return 0. Changing to use sys.exit on the exception allows the whole tool to exit with error code 1 and keeps the error on stderr.
