### PR TITLE
Add Support for `pip`'s `--platform`, `--no-binary`, & `--only-binary` options

### DIFF
--- a/locallibs/__init__.py
+++ b/locallibs/__init__.py
@@ -1,0 +1,44 @@
+# encoding: utf-8
+#
+# Copyright 2018 Greg Neagle.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Misc Helper Functions"""
+
+def vararg_callback(option, opt_str, value, parser):
+    """Optparse callback to support a variable number of arguments.
+    This is example 6 from the official docs:
+    https://docs.python.org/3/library/optparse.html#callback-example-6-variable-arguments
+    """
+
+    assert value is None
+    value = []
+
+    def floatable(str):
+        try:
+            float(str)
+            return True
+        except ValueError:
+            return False
+
+    for arg in parser.rargs:
+        # stop on --foo like options
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        # stop on -a, but not on -3 or -3.0
+        if arg[:1] == "-" and len(arg) > 1 and not floatable(arg):
+            break
+        value.append(arg)
+
+    del parser.rargs[:len(value)]
+    setattr(parser.values, option.dest, value)

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -81,7 +81,7 @@ def install_requirements(requirements_file, framework_path, version, pip_platfor
     if pip_platform:
         for platform in pip_platform:
             cmd.append["--platform", platform]
-        cmd.append["--target==%s" % site_packages_path]
+        cmd.append["--target=%s" % site_packages_path]
 
     pip_env = os.environ
     pip_env["CPPFLAGS"] = "-I%s" % headers_path

--- a/locallibs/install.py
+++ b/locallibs/install.py
@@ -61,7 +61,7 @@ def upgrade_pip_install(framework_path, version):
     subprocess.check_call(cmd)
 
 
-def install_requirements(requirements_file, framework_path, version):
+def install_requirements(requirements_file, framework_path, version, pip_platform):
     """Use pip to install a Python pkg into framework_path"""
     python_path = os.path.join(
         framework_path, "Versions", version, "bin/python" + version
@@ -69,10 +69,20 @@ def install_requirements(requirements_file, framework_path, version):
     headers_path = os.path.abspath(os.path.join(
         framework_path, "Versions", version, "include/python" + version
     ))
+    site_packages_path = os.path.join(
+        framework_path, "Versions", version, "lib/python" + version
+        + "/site-packages"
+    )
     if not os.path.exists(python_path):
         print("No python at %s" % python_path, file=sys.stderr)
         return
     cmd = [python_path, "-s", "-m", "pip", "install", "-r", requirements_file]
+
+    if pip_platform:
+        for platform in pip_platform:
+            cmd.append["--platform", platform]
+        cmd.append["--target==%s" % site_packages_path]
+
     pip_env = os.environ
     pip_env["CPPFLAGS"] = "-I%s" % headers_path
     print("Installing modules from %s..." % requirements_file)
@@ -85,6 +95,7 @@ def install_extras(
     requirements_file=None,
     upgrade_pip=False,
     without_pip=False,
+    pip_platform=None
 ):
     """install all extra pkgs into Python framework path"""
     print()
@@ -111,6 +122,6 @@ def install_extras(
             upgrade_pip_install(framework_path, version)
         if requirements_file:
             print()
-            install_requirements(requirements_file, framework_path, version)
+            install_requirements(requirements_file, framework_path, version, pip_platform)
     else:
         print("Skipping all requirements, packages, etc due to without-pip specified")

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -85,8 +85,26 @@ def main():
         "Default is to the platform of the running system. "
         "Use this option multiple times to specify multiple platforms."
     )
+    parser.add_option(
+        "--no-binary", dest="no_binary",
+        action="callback", callback=vararg_callback,
+        help="Do not use binary packages. "
+        "Can be supplied multiple times, and each time adds to the existing value. "
+        "Accepts either ':all:' to disable all binary packages, ':none:' to empty the set "
+        "(notice the colons), or one or more package names with commas between them (no colons)."
+    )
+    parser.add_option(
+        "--only-binary", dest="only_binary",
+        action="callback", callback=vararg_callback,
+        help="Do not use source packages. "
+        "Can be supplied multiple times, and each time adds to the existing value. "
+        "Accepts either ':all:' to disable all binary packages, ':none:' to empty the set "
+        "(notice the colons), or one or more package names with commas between them (no colons)."
+    )
     parser.set_defaults(unsign=True)
     options, _arguments = parser.parse_args()
+    if options.no_binary and options.only_binary:
+        parser.error("The options --no-binary and --only-binary are mutually exclusive")
     framework_path = get.FrameworkGetter(
         python_version=options.python_version,
         os_version=options.os_version,
@@ -104,7 +122,9 @@ def main():
             requirements_file=options.pip_requirements,
             upgrade_pip=options.upgrade_pip,
             without_pip=options.without_pip,
-            pip_platform=options.pip_platform
+            pip_platform=options.pip_platform,
+            no_binary=options.no_binary,
+            only_binary=options.only_binary
         )
         if fix_other_things(framework_path, short_version):
             print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -78,6 +78,13 @@ def main():
         action="store_true",
         help="Do not install pip."
     )
+    parser.add_option(
+        "--pip-platform",
+        nargs=3,
+        help="Specify which platform the requirements should be downloaded for. "
+        "Default is to the platform of the running system. "
+        "Use this option multiple times to specify multiple platforms."
+    )
     parser.set_defaults(unsign=True)
     options, _arguments = parser.parse_args()
     framework_path = get.FrameworkGetter(
@@ -96,7 +103,8 @@ def main():
             version=short_version,
             requirements_file=options.pip_requirements,
             upgrade_pip=options.upgrade_pip,
-            without_pip=options.without_pip
+            without_pip=options.without_pip,
+            pip_platform=options.pip_platform
         )
         if fix_other_things(framework_path, short_version):
             print()

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -81,15 +81,15 @@ def main():
     parser.add_option(
         "--pip-platform", dest="pip_platform",
         action="callback", callback=vararg_callback,
-        help="Specify which platform the requirements should be downloaded for. "
+        help="Specify which platform the pip should be downloaded for. "
         "Default is to the platform of the running system. "
-        "Use this option multiple times to specify multiple platforms."
+        "Multiple values can be passed to specify multiple platforms."
     )
     parser.add_option(
         "--no-binary", dest="no_binary",
         action="callback", callback=vararg_callback,
         help="Do not use binary packages. "
-        "Can be supplied multiple times, and each time adds to the existing value. "
+        "Multiple values can be passed, and each time adds to the existing value. "
         "Accepts either ':all:' to disable all binary packages, ':none:' to empty the set "
         "(notice the colons), or one or more package names with commas between them (no colons)."
     )
@@ -97,7 +97,7 @@ def main():
         "--only-binary", dest="only_binary",
         action="callback", callback=vararg_callback,
         help="Do not use source packages. "
-        "Can be supplied multiple times, and each time adds to the existing value. "
+        "Multiple values can be passed, and each time adds to the existing value. "
         "Accepts either ':all:' to disable all binary packages, ':none:' to empty the set "
         "(notice the colons), or one or more package names with commas between them (no colons)."
     )

--- a/make_relocatable_python_framework.py
+++ b/make_relocatable_python_framework.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 import optparse
 
-from locallibs import get
+from locallibs import get, vararg_callback
 from locallibs.fix import fix_broken_signatures, fix_other_things
 from locallibs.install import install_extras
 from locallibs.relocatablizer import relocatablize
@@ -79,8 +79,8 @@ def main():
         help="Do not install pip."
     )
     parser.add_option(
-        "--pip-platform",
-        nargs=3,
+        "--pip-platform", dest="pip_platform",
+        action="callback", callback=vararg_callback,
         help="Specify which platform the requirements should be downloaded for. "
         "Default is to the platform of the running system. "
         "Use this option multiple times to specify multiple platforms."


### PR DESCRIPTION
This feature allows the user to specify additional `pip` options to filter against when installing libraries.

Particularly, I ran into an issue where I was wanting to build a "Universal" relocatable Python.Framework, but `pip` will natively install the a matching architecture wheel if available, even if a universal build is available.

With the support for these three options, I also included the ability to pass multiple values for each option (which `pip` supports), but `optparse` does not, so a callback function was added in `locallibs/__init__.py` to support this.

Example usage would be:
```shell
./make_relocatable_python_framework.py \
  --os-version 11 \
  --python-version 3.11.6 \
  --pip-requirements requirements.txt \
  --pip-platform macosx_11_0_universal2 macosx_11_0_arm64 macosx_10_9_x86_64 \
  --only-binary :all: \
  --upgrade-pip
```

