### PR TITLE
add handling for paths containing symlinks

### DIFF
--- a/locallibs/fix.py
+++ b/locallibs/fix.py
@@ -55,7 +55,9 @@ def relativize_interpreter_path(framework_path, script_dir, shebang_line):
         original_path = original_path.replace(
             default_framework_path, current_framework_path, 1)
     return os.path.relpath(
-        original_path, os.path.abspath(script_dir).encode("UTF-8"))
+        os.path.realpath(original_path),
+        os.path.realpath(script_dir).encode("UTF-8")
+    )
 
 
 def is_framework_shebang(framework_path, text):
@@ -63,8 +65,10 @@ def is_framework_shebang(framework_path, text):
     referencing the framework_path or the default
     /Library/Frameworks/Python.framework path"""
     this_framework_shebang = b"#!" + os.path.abspath(framework_path).encode("UTF-8")
+    real_framework_shebang = b"#!" + os.path.realpath(framework_path).encode("UTF-8")
     prefixes = [
         this_framework_shebang,
+        real_framework_shebang,
         b"#!/Library/Frameworks/Python.framework",
         b"#!/Library/Developer/CommandLineTools/usr/bin/python3",
         b"#!/Applications/Xcode.app/Contents/Developer/usr/bin/python3",

--- a/locallibs/fix.py
+++ b/locallibs/fix.py
@@ -64,11 +64,9 @@ def is_framework_shebang(framework_path, text):
     """Returns a boolean to indicate if the text starts with a shebang
     referencing the framework_path or the default
     /Library/Frameworks/Python.framework path"""
-    this_framework_shebang = b"#!" + os.path.abspath(framework_path).encode("UTF-8")
-    real_framework_shebang = b"#!" + os.path.realpath(framework_path).encode("UTF-8")
+    this_framework_shebang = b"#!" + os.path.realpath(framework_path).encode("UTF-8")
     prefixes = [
         this_framework_shebang,
-        real_framework_shebang,
         b"#!/Library/Frameworks/Python.framework",
         b"#!/Library/Developer/CommandLineTools/usr/bin/python3",
         b"#!/Applications/Xcode.app/Contents/Developer/usr/bin/python3",


### PR DESCRIPTION
If you build this in a path that contains a symlink (such as `/var` or `/tmp` which are symlinks to `/private/var` and `/private/tmp`) the shebang doesn't always get modified.

You can replicate this by running
`./make_relocatable_python_framework.py --python-version 3.12.7 --os-version 11 --destination /tmp/ && cat /tmp/Python.framework/Versions/3.12/bin/pip3 | grep '#!'`

Which will show the shebang for pip is still `#!/private/tmp/Python.framework/Versions/3.12/bin/python3.12`

This adds some additional handling so that it can fix shebangs that contain these symlinked paths by converting them to real paths. I've tested this change with "regular" paths that do not contain symlinks and the shebangs get modified as expected.